### PR TITLE
Allow manual run range definition in scaleMonitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 # Images
 *.pdf
 *.png
+
+# build directory
+build

--- a/interface/CfgManagerT.h
+++ b/interface/CfgManagerT.h
@@ -28,6 +28,22 @@ template<> inline std::string CfgManager::GetOpt(std::string key, int opt)
     return opts_[key][opt];
 }   
 
+template<> inline std::vector<UInt_t> CfgManager::GetOpt(std::string key, int opt)
+{
+    key = "opts."+key;
+    Errors(key, opt);
+    std::vector<UInt_t> optsVect;
+    for(unsigned int iOpt=opt; iOpt<opts_[key].size(); ++iOpt)
+    {
+        UInt_t opt_val;
+        std::istringstream buffer(opts_[key][iOpt]);
+        buffer >> opt_val;
+        optsVect.push_back(opt_val);
+    }
+    
+    return optsVect;
+}    
+
 template<> inline std::vector<float> CfgManager::GetOpt(std::string key, int opt)
 {
     key = "opts."+key;

--- a/interface/MonitoringManager.h
+++ b/interface/MonitoringManager.h
@@ -32,6 +32,7 @@ class MonitoringManager: public calibrator
   TH1F* BuildTemplate();
   void  RunDivide();
   void  SaveTimeBins(std::string outfilename, std::string writemethod="RECREATE");
+  void  LoadTimeBins(std::vector<UInt_t>& runs, std::vector<UInt_t>& times, std::string option="");
   void  LoadTimeBins(string inputfilename, string objname="", std::string option="");
   void  LoadIntegratedLuminosity(string intlumi_vs_time_filename);
   void  FillTimeBins();

--- a/main/LaserMonitoring.cpp
+++ b/main/LaserMonitoring.cpp
@@ -82,17 +82,26 @@ int main(int argc, char* argv[])
   if(scaleMonitor)
   {
 
-    vector<string> inputconf = config.GetOpt<vector<string> >("LaserMonitoring.scaleMonitor.runranges");
-    string inputfilename="";
-    string objname="";
-    if(inputconf.size()==1)
-      inputfilename = inputconf.at(0);
+    if(config.OptExist("LaserMonitoring.scaleMonitor.runtimes"))
+    {
+      auto runranges = config.GetOpt<vector<UInt_t> >("LaserMonitoring.scaleMonitor.runranges");
+      auto runtimes = config.GetOpt<vector<UInt_t> >("LaserMonitoring.scaleMonitor.runtimes");
+      monitor.LoadTimeBins(runranges, runtimes);
+    }
     else
     {
-      objname = inputconf.at(0);
-      inputfilename = inputconf.at(1);
+      vector<string> inputconf = config.GetOpt<vector<string> >("LaserMonitoring.scaleMonitor.runranges");
+      string inputfilename="";
+      string objname="";
+      if(inputconf.size()==1)
+        inputfilename = inputconf.at(0);
+      else
+      {
+        objname = inputconf.at(0);
+        inputfilename = inputconf.at(1);
+      }
+      monitor.LoadTimeBins(inputfilename,objname);
     }
-    monitor.LoadTimeBins(inputfilename,objname);
 
     //fill the histos (one histo per time bin) 
     monitor.FillTimeBins();

--- a/src/MonitoringManager.cc
+++ b/src/MonitoringManager.cc
@@ -283,6 +283,37 @@ void  MonitoringManager::SaveTimeBins(std::string outfilename, std::string write
   outfile->Close();
 }
 
+// create list of time bins from list of runs
+// this function is meant to use by the automatic prompt calibration system
+void  MonitoringManager::LoadTimeBins(std::vector<UInt_t>& runs, std::vector<UInt_t>& times, std::string option)
+{
+  cout<<">> Loading timebins"<<endl; 
+  if(timebins.size()>0)
+    if(option=="RELOAD")
+      timebins.clear();
+    else
+    {
+      cout<<"[WARNING]: timebins not loaded because already in memory"<<endl
+	  <<"           if you want to overwrite call LoadTimeBins(inputfilename, objname, \"RELOAD\")"<<endl;
+      return;
+    }
+  if(runs.size() < 2)
+    {
+      cout<<"[ERROR]: Not enough runs specified in LoadTimeBins (at least two required)"<<endl;
+      return;
+    }
+    
+  for(unsigned int i=1; i<runs.size(); ++i)
+  {      
+    TimeBin ibin;
+    ibin.SetBinRanges(runs[i-1], runs[i], 0, std::numeric_limits<bool>::max(), times[i-1], times[i]);
+    timebins.push_back(ibin);
+  }
+  std::sort(timebins.begin(), timebins.end());//It should be already ordered, just for security
+  cout<<">> Loaded "<<timebins.size()<<" bins"<<endl;
+  last_accessed_bin_=timebins.end();    
+}
+
 void  MonitoringManager::LoadTimeBins(string inputfilename, string objname, std::string option)
 {
   cout<<">> Loading timebins"<<endl; 


### PR DESCRIPTION
this development is required to be able to run the harness monitoring as part of the automatic prompt reco calibration. The run ranges cannot be chosen on the fly but are set by the automation script, hence they has to be specified through the config file.